### PR TITLE
Add requirement from client for check on arguments

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -1,4 +1,8 @@
 module.exports = function calculator(operator, x, y) {
+  if (arguments.length !== 3) {
+    throw Error("INCORRECT_NUMBER_OF_ARGUMENTS: 3 arguments expected");
+  }
+
   if (isNaN(x)) {
     throw Error(`${x} is not a number`);
   }
@@ -6,23 +10,24 @@ module.exports = function calculator(operator, x, y) {
     throw Error(`${y} is not a number`);
   }
 
-  if (operator === "+") {
-    return x + y;
-  } else if (operator === "-") {
-    return x - y;
-  } else if (operator === "*") {
-    return x * y;
-  } else if (operator === "/") {
-    if (y === 0) {
-      throw Error("Cannot divide by 0");
-    }
-    return x / y;
-  } else if (operator === "%") {
-    if (y === 0) {
-      throw Error("Cannot divide by 0");
-    }
-    return x % y;
-  } else {
-    throw Error(`OPERATOR_UNKNOWN: "${operator}"`);
+  switch (operator) {
+    case "+":
+      return x + y;
+    case "-":
+      return x - y;
+    case "*":
+      return x * y;
+    case "/":
+      if (y === 0) {
+        throw Error("Cannot divide by 0");
+      }
+      return x / y;
+    case "%":
+      if (y === 0) {
+        throw Error("Cannot divide by 0");
+      }
+      return x % y;
+    default:
+      throw Error(`OPERATOR_UNKNOWN: "${operator}"`);
   }
 };

--- a/calculator.spec.js
+++ b/calculator.spec.js
@@ -1,6 +1,20 @@
 const calculator = require("./calculator");
 
 describe("calculator", () => {
+  test("should complain if the number of arguments is incorrect", () => {
+    expect(() => {
+      calculator("+", 1);
+      // IMPORTANT!! DO NOT CHANGE THIS
+      // The client needs the error to be in this exact format
+    }).toThrowError(/^INCORRECT_NUMBER_OF_ARGUMENTS: 3 arguments expected$/);
+
+    expect(() => {
+      calculator("+", 1, 2, 3);
+      // IMPORTANT!! DO NOT CHANGE THIS
+      // The client needs the error to be in this exact format
+    }).toThrowError(/^INCORRECT_NUMBER_OF_ARGUMENTS: 3 arguments expected$/);
+  });
+
   test("should complain if operator is unknown", () => {
     expect(() => {
       calculator("test", 1, 2);


### PR DESCRIPTION
The client has requested a special feature
to throw an error when we have the wrong amount
of arguments.

I've added a test to check that we send the correct string in this
scenario